### PR TITLE
feat: add minimum severity parameter to pint lint cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ to `pint` and it will use defaults.
 Log level for pint. Default is `""`, meaning no `--log-level` flag will be passed
 to `pint` and it will use defaults.
 
+### `minSeverity`
+
+Minimum severity reported by the **lint** command. Default is `""`, meaning no `--min-severity` flag will be passed
+to `pint` and it will use defaults.
+
+Available options : `info`, `warning` *(lint default)*, `bug` `fatal`.
+
 ## Requirements
 
 Validating PRs require full git history and so `actions/checkout` must be used

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Log level to use"
     required: false
     default: ""
+  minSeverity:
+    description: "Minimum severity to report"
+    required: false
+    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -27,3 +31,4 @@ runs:
     CONFIG: ${{ inputs.config }}
     WORKDIR: ${{ inputs.workdir }}
     LOGLEVEL: ${{ inputs.loglevel }}
+    MIN_SEVERITY: ${{ inputs.minSeverity }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,12 @@ if  [ "$LOGLEVEL" != "" ]; then
     LOGLEVEL="--log-level=$LOGLEVEL"
 fi
 
+if  [ "$MIN_SEVERITY" != "" ]; then
+    MIN_SEVERITY="--min-severity=$MIN_SEVERITY"
+fi
+
 if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-    pint $CONFIG $LOGLEVEL lint $WORKDIR
+    pint $CONFIG $LOGLEVEL lint $MIN_SEVERITY $WORKDIR
 else
     CMD="ci"
     BASEBRANCH="$GITHUB_BASE_REF"


### PR DESCRIPTION
# Description

Hello, thank you for providing pint's action 🙂 

I wanted to allow setting the minimum severity reported by the linter in cases where we want to filter a bit the output.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Tested locally