### PR TITLE
feat: support PRs from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }} # REQUIRED FOR PRs FROM FORKS | https://github.com/actions/checkout/issues/124#issuecomment-586664611
 
       - name: Run pint
         uses: prymitive/pint-action@v1
@@ -119,5 +120,10 @@ jobs:
 
 Some caveats:
 
-- The `pull_requests` permission will *not* be granted "write" access by default (TODO link to internal docs)
-- `pr_target_repo` and `pr_source_repo` must both be set to the values indicated
+- The `pull_requests` permission will *not* be granted "write" access [for pull request from public forks](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token). This is a GitHub limitation.
+- `pr_target_repo` and `pr_source_repo` must both be set to the variables indicated
+- `actions/checkout@v3` must be set with `ref: ${{ github.event.pull_request.head.sha }}`
+
+The only work around to get `pull-requests: write` permission on the default GITHUB_TOKEN is to make your repository private. For example, this can work well in a Github Enterprise environment. Github has chosen to set "Maximum access for pull requests from public forked repositories" to "read" on every single token scope.
+
+Once your repository is private, you can set `Send write tokens to workflows from fork pull requests` or `Send secrets and variables to workflows from fork pull requests` under the Actions settings menu.

--- a/README.md
+++ b/README.md
@@ -80,3 +80,44 @@ jobs:
           workdir: 'rules'
           requireOwner: 'true'
 ```
+
+## Pull Requests from Forks
+
+It is possible to use Pint with pull requests originating from forked repositories. There is some additional configuration. An example configuration could look like:
+
+```YAML
+name: pint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run pint
+        uses: prymitive/pint-action@v1
+        with:
+          token: ${{ github.token }}
+          workdir: 'rules'
+          requireOwner: 'true'
+          pr_target_repo: ${{ github.event.pull_request.base.repo.full_name }} # REQUIRED FOR PRs FROM FORKS
+          pr_source_repo: ${{ github.event.pull_request.head.repo.full_name }} # REQUIRED FOR PRs FROM FORKS
+```
+
+Some caveats:
+
+- The `pull_requests` permission will *not* be granted "write" access by default (TODO link to internal docs)
+- `pr_target_repo` and `pr_source_repo` must both be set to the values indicated

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,16 @@ inputs:
     description: "Require all rules to have an owner set via comment"
     required: false
     default: ""
-    
+  pr_target_repo:
+    description: "Required for pull requests from forks - target PR repository"
+    required: false
+    default: ""
+  pr_source_repo:
+    description: "Required for pull requests from forks - source PR repository"
+    required: false
+    default: ""
+
+
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -38,3 +47,5 @@ runs:
     LOGLEVEL: ${{ inputs.loglevel }}
     MIN_SEVERITY: ${{ inputs.minSeverity }}
     REQUIRE_OWNER: ${{ inputs.requireOwner }}
+    PULL_REQUEST_TARGET_REPO: ${{ inputs.pr_target_repo }}
+    PULL_REQUEST_SOURCE_REPO: ${{ inputs.pr_source_repo }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,11 +17,11 @@ if  [ "$REQUIRE_OWNER" != "" ]; then
 fi
 
 if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-    pint $CONFIG $LOGLEVEL lint $MIN_SEVERITY $REQUIRE_OWNER $WORKDIR
+    pint "$CONFIG" "$LOGLEVEL" lint "$MIN_SEVERITY" "$REQUIRE_OWNER" "$WORKDIR"
 else
     CMD="ci"
     echo ">>> GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
-    git config --global --add safe.directory ${GITHUB_WORKSPACE}
+    git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
     # we must have both target/source repo values populated, and they should differ to indicate the PR is from a fork
     if [ "${PULL_REQUEST_TARGET_REPO}" != "" ] && [ "${PULL_REQUEST_SOURCE_REPO}" != "" ] && [ "${PULL_REQUEST_TARGET_REPO}" != "${PULL_REQUEST_SOURCE_REPO}" ]; then
@@ -43,23 +43,23 @@ else
         # # https://github.com/reg-viz/reg-suit/issues/590#issuecomment-1219155722
         # workaround for detached head
         # force delete any existing branch we could have
-        git branch -D ${GITHUB_HEAD_REF#refs/heads/} || true
+        git branch -D "${GITHUB_HEAD_REF#refs/heads/}" || true
         # TODO - I think if the PR from a fork has the same branch name as BASEBRANCH this could go awry
-        git checkout -b ${GITHUB_HEAD_REF#refs/heads/}
+        git checkout -b "${GITHUB_HEAD_REF#refs/heads/}"
         # make a new local branch with our upstream data
-        git branch --set-upstream-to=origin/$BASEBRANCH ${GITHUB_HEAD_REF}
+        git branch --set-upstream-to=origin/"$BASEBRANCH" "${GITHUB_HEAD_REF}"
         git pull
 
         # populate a local base branch with upstream data
-        git checkout remotes/origin/$BASEBRANCH
-        git branch $BASEBRANCH
-        git reset --hard remotes/origin/$BASEBRANCH
+        git checkout remotes/origin/"$BASEBRANCH"
+        git branch "$BASEBRANCH"
+        git reset --hard remotes/origin/"$BASEBRANCH"
         # helpful debug step
         git remote -v
-        git pull origin $BASEBRANCH
+        git pull origin "$BASEBRANCH"
 
         # go back to our fork branch
-        git checkout ${GITHUB_HEAD_REF#refs/heads/}
+        git checkout "${GITHUB_HEAD_REF#refs/heads/}"
     else
         # pull request is not from fork
         echo ">>> Running steps for PR from trunk (not fork)"
@@ -73,6 +73,6 @@ else
         git checkout "$PRBRANCH"
 
     fi
-        pint $CONFIG $LOGLEVEL $CMD --base-branch="$BASEBRANCH" $REQUIRE_OWNER
+        pint "$CONFIG" "$LOGLEVEL" $CMD --base-branch="$BASEBRANCH" "$REQUIRE_OWNER"
 
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ else
         # TODO - I think if the PR from a fork has the same branch name as BASEBRANCH this could go awry
         git checkout -b ${GITHUB_HEAD_REF#refs/heads/}
         # make a new local branch with our upstream data
-        git branch --set-upstream-to=origin/master ${GITHUB_HEAD_REF}
+        git branch --set-upstream-to=origin/$BASEBRANCH ${GITHUB_HEAD_REF}
         git pull
 
         # populate a local base branch with upstream data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,18 +20,59 @@ if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
     pint $CONFIG $LOGLEVEL lint $MIN_SEVERITY $REQUIRE_OWNER $WORKDIR
 else
     CMD="ci"
-    BASEBRANCH="$GITHUB_BASE_REF"
-    PRBRANCH="$GITHUB_HEAD_REF"
-    echo ">>> BASE BRANCH: $BASEBRANCH"
-    echo ">>> PR BRANCH: $PRBRANCH"
-
     echo ">>> GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
     git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    
-    git fetch origin "$BASEBRANCH"
-    git checkout "$BASEBRANCH"
-    git fetch origin "$PRBRANCH"
-    git checkout "$PRBRANCH"
 
-    pint $CONFIG $LOGLEVEL ci --base-branch="$BASEBRANCH" $REQUIRE_OWNER
+    # we must have both target/source repo values populated, and they should differ to indicate the PR is from a fork
+    if [ "${PULL_REQUEST_TARGET_REPO}" != "" ] && [ "${PULL_REQUEST_SOURCE_REPO}" != "" ] && [ "${PULL_REQUEST_TARGET_REPO}" != "${PULL_REQUEST_SOURCE_REPO}" ]; then
+    # pull request is from fork
+        echo ">>> Running steps for PR from fork"
+        BASEBRANCH="${GITHUB_BASE_REF#refs/heads/}"
+        echo ">>> BASE BRANCH: $BASEBRANCH"
+        echo ">>> GITHUB HEAD REF: ${GITHUB_HEAD_REF}"
+
+        # must set these values for the git pull
+        git config --global user.email "pint@fakemail.com"
+        git config --global user.name "pint"
+        git config pull.rebase false
+
+        # makes output cleaner
+        git config --global advice.detachedHead false
+
+        # # https://github.com/reg-viz/reg-suit#workaround-for-detached-head
+        # # https://github.com/reg-viz/reg-suit/issues/590#issuecomment-1219155722
+        # workaround for detached head
+        # force delete any existing branch we could have
+        git branch -D ${GITHUB_HEAD_REF#refs/heads/} || true
+        # TODO - I think if the PR from a fork has the same branch name as BASEBRANCH this could go awry
+        git checkout -b ${GITHUB_HEAD_REF#refs/heads/}
+        # make a new local branch with our upstream data
+        git branch --set-upstream-to=origin/master ${GITHUB_HEAD_REF}
+        git pull
+
+        # populate a local base branch with upstream data
+        git checkout remotes/origin/$BASEBRANCH
+        git branch $BASEBRANCH
+        git reset --hard remotes/origin/$BASEBRANCH
+        # helpful debug step
+        git remote -v
+        git pull origin $BASEBRANCH
+
+        # go back to our fork branch
+        git checkout ${GITHUB_HEAD_REF#refs/heads/}
+    else
+        # pull request is not from fork
+        echo ">>> Running steps for PR from trunk (not fork)"
+        BASEBRANCH="$GITHUB_BASE_REF"
+        PRBRANCH="$GITHUB_HEAD_REF"
+        echo ">>> BASE BRANCH: $BASEBRANCH"
+        echo ">>> PR BRANCH: $PRBRANCH"
+        git fetch origin "$BASEBRANCH"
+        git checkout "$BASEBRANCH"
+        git fetch origin "$PRBRANCH"
+        git checkout "$PRBRANCH"
+
+    fi
+        pint $CONFIG $LOGLEVEL $CMD --base-branch="$BASEBRANCH" $REQUIRE_OWNER
+
 fi


### PR DESCRIPTION
This will enable Pint to run the `ci` check on pull requests originating
from a forked repository. I run a similar setup on GHE 3.9.

It works by creating a local branch in the workflow with the same
changes as the PR from the fork. There are a few workarounds and
required settings.

This works fairly well but has one flaw that we've run into on GHE.

```
error="submitting reports: failed to create review: POST https://<my_GHE_instance>/api/v3/repos/ops/prometheus_rules/pulls/227/reviews: 422 Unprocessable Entity [{Resource: Field: Code: Message:The commitOID is not part of the pull request}]"
```

happens occasionally. I haven't been able to track down why yet. However
this provides enough value for us that I thought it was worthwhile to PR
upstream. I would say it happens on ~10-20% of PRs with no commonality.

This shouldn't impact normal operation. I tested it here: https://github.com/wbollock/source_pint_repo/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

The test repo is public so Pint won't get posting permissions as
explained in the README.

Resolves: #36