### PR TITLE
fix: entrypoint fork checkout conflicting names

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ else
         # make new branch, locally
         git checkout -b "${localbranch}"
         # make a new local branch with our upstream data
-        git branch --set-upstream-to=origin/"$BASEBRANCH" "${GITHUB_HEAD_REF}"
+        git branch --set-upstream-to=origin/"$BASEBRANCH" "${localbranch}"
         git pull
 
         # populate a local base branch with upstream data


### PR DESCRIPTION
Continues work from b2eecca

We need to set the modified branch name to track the upstream (unmodified) branch name.

## Before

```console
 >>> GITHUB_WORKSPACE: /github/workspace
>>> Running steps for PR from fork
>>> BASE BRANCH: main
>>> GITHUB HEAD REF: main
error: branch 'main_fork' not found.
Switched to a new branch 'main_fork'
fatal: branch 'main' does not exist
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

If you wish to set tracking information for this branch you can do so with:

    git branch --set-upstream-to=origin/<branch> main_fork

HEAD is now at 7efb132 Merge pull request #834 from whegedus/doc/directory-structure
HEAD is now at 7efb132 Merge pull request #834 from whegedus/doc/directory-structure
origin	https://<redacted>/ops/prometheus_rules (fetch)
origin	https://<redacted>/ops/prometheus_rules (push)
From https://<redacted>/ops/prometheus_rules
 * branch            main       -> FETCH_HEAD
Already up to date.
Previous HEAD position was 7efb132 Merge pull request #834 from whegedus/doc/directory-structure
Switched to branch 'main_fork'
>>> Running: pint --config=./.pint.hcl  ci --base-branch=main 
```

## After

```console
>>> GITHUB_WORKSPACE: /github/workspace
>>> Running steps for PR from fork
>>> BASE BRANCH: main
>>> GITHUB HEAD REF: main
error: branch 'main_fork' not found.
Switched to a new branch 'main_fork'
branch 'main_fork' set up to track 'origin/main'.
Already up to date.
HEAD is now at 5680333 ci: test pint-action fix
HEAD is now at 5680333 ci: test pint-action fix
origin	https://<redacted>/ops/prometheus_rules (fetch)
origin	https://<redacted>/ops/prometheus_rules (push)
From https://<redacted>/ops/prometheus_rules
 * branch            main       -> FETCH_HEAD
Already up to date.
Previous HEAD position was 5680333 ci: test pint-action fix
Switched to branch 'main_fork'
Your branch is ahead of 'origin/main' by 12 commits.
  (use "git push" to publish your local commits)
>>> Running: pint --config=./.pint.hcl  ci --base-branch=main 
```